### PR TITLE
Properly support the id attribute in the shortcode

### DIFF
--- a/inc/Core/Frontend/Shortcode.php
+++ b/inc/Core/Frontend/Shortcode.php
@@ -92,8 +92,8 @@ class Shortcode extends PostView
 			return;
 		}
 
-		$published_timestamp = get_post_time( 'U' );
-		$modified_timestamp = get_post_modified_time( 'U' );
+		$published_timestamp = get_post_time( 'U', false, $get_post );
+		$modified_timestamp = get_post_modified_time( 'U', false, $get_post );
 		if ( ( $modified_timestamp - $published_timestamp ) < $atts['gap'] ) {
 			return;
 		}
@@ -102,7 +102,7 @@ class Shortcode extends PostView
 
 		$timestamp = human_time_diff( $modified_timestamp, current_time( 'U' ) );
 		if ( $date_type == 'default' ) {
-			$timestamp = $this->get_modified_date( $atts['date_format'] );
+			$timestamp = $this->get_modified_date( $atts['date_format'], $get_post );
 		}
 		$timestamp = $this->do_filter( 'post_datetime_format', $timestamp, $get_post->ID );
 


### PR DESCRIPTION
This PR fixes an issue when the `id` attribute used in the shortcode is different than the current post ID, the displayed last modified time is the time for the current post, but not the post specified with the `id` attribute.

Since the shortcode supports the `id` attribute, I assume we would want the "last modified time" to be the time for the specified post, but not the current post. Hence submitting the PR.